### PR TITLE
Jitpack compatibility & coroutine fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.application' version '7.4.0' apply false
-    id 'com.android.library' version '7.4.0' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
     id 'org.jetbrains.dokka' version '1.8.20' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jan 27 17:03:50 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/treessence/src/main/java/fr/bipi/treessence/file/FileLoggerTree.kt
+++ b/treessence/src/main/java/fr/bipi/treessence/file/FileLoggerTree.kt
@@ -255,7 +255,7 @@ open class FileLoggerTree @JvmOverloads constructor(
                 logger.addHandler(this)
             }
 
-            return FileLoggerTree(logger, fileHandler, path, fileLimit, priority, filter, formatter)
+            return FileLoggerTree(logger, fileHandler, path, fileLimit, priority, filter, formatter, loggingCoroutineScope)
         }
 
         /**


### PR DESCRIPTION
- Drop Gradle until Jitpack supports 7.4.0
- Make sure `loggingCoroutineScope` is included in `FileLoggerTree` initializer.